### PR TITLE
Persist 24h checked product checkbox

### DIFF
--- a/src/components/show-products/index.js
+++ b/src/components/show-products/index.js
@@ -1,13 +1,26 @@
 import React from 'react';
 import { useHistory } from 'react-router';
 import Button from '../button';
+import { updatePurchaseDate } from '../../utils/firebaseUtils';
 import { useProducts } from '../../hooks/useProducts';
+import {
+  useLocalStorage,
+  LOCAL_STORAGE_LIST_TOKEN,
+} from '../../hooks/useLocalStorage';
+import { TimeFrames } from '../../utils/timeFrames';
+import { compareDates } from '../../utils/compareDates';
 import ContentContainer from '../content-container';
 import './styles.css';
 
 export const ShowProducts = () => {
   const { products, loading } = useProducts();
   const { push } = useHistory();
+  const { storedValue } = useLocalStorage(LOCAL_STORAGE_LIST_TOKEN);
+  const timeFrames = TimeFrames;
+
+  const handleOnChange = (productID) => {
+    updatePurchaseDate(productID, storedValue);
+  };
 
   if (loading) {
     return (
@@ -31,8 +44,25 @@ export const ShowProducts = () => {
   return (
     <ContentContainer>
       <ul>
-        {products.map(({ id, productName }) => (
-          <li key={id}>{productName}</li>
+        {products?.map(({ id, productName, lastPurchaseDate, timeFrame }) => (
+          <li className="checkbox-item" key={id}>
+            <label htmlFor={id} className="checkbox-label">
+              <input
+                type="checkbox"
+                id={id}
+                name={productName}
+                onChange={() => handleOnChange(id)}
+                checked={
+                  lastPurchaseDate && compareDates(lastPurchaseDate.toDate())
+                }
+                ariaLabel={timeFrames[timeFrame]}
+              />
+              <span
+                className={`checkmark checkbox-timeFrame-${timeFrame}`}
+              ></span>
+              <span className="checkbox-name">{productName}</span>
+            </label>
+          </li>
         ))}
       </ul>
     </ContentContainer>

--- a/src/components/show-products/styles.css
+++ b/src/components/show-products/styles.css
@@ -1,3 +1,72 @@
 .empty-shopping-list {
   margin-bottom: 20px;
 }
+
+/* Customize the label (the container) */
+.checkbox-label {
+  display: block;
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+  padding-left: 35px;
+  text-align: left;
+}
+
+/* Hide the browser's default checkbox */
+.checkbox-label input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+.checkbox-item {
+  margin-bottom: 10px;
+}
+
+/* Create a custom checkbox */
+.checkmark {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  height: 18px;
+  width: 18px;
+  border: 1px solid black;
+  border-radius: 4px;
+}
+
+/* Create the checkmark/indicator (hidden when not checked) */
+.checkmark:after {
+  content: '';
+  position: absolute;
+  display: none;
+}
+
+/* Show the checkmark when checked */
+.checkbox-label input:checked ~ .checkmark:after {
+  display: block;
+}
+
+/* Style the checkmark/indicator */
+.checkbox-label .checkmark:after {
+  left: 4px;
+  top: 1px;
+  width: 6px;
+  height: 8px;
+  border: solid black;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.checkbox-timeFrame-7 {
+  background-color: #fcb6b6;
+}
+
+.checkbox-timeFrame-14 {
+  background-color: #fff0d4;
+}
+
+.checkbox-timeFrame-30 {
+  background-color: #e5f5e2;
+}

--- a/src/helpers/firebaseHelpers.js
+++ b/src/helpers/firebaseHelpers.js
@@ -1,3 +1,5 @@
+// In this file we add the utility functions that we can reuse in other parts of the code (data parse, filters) that are related to using Firebase
+
 export const parseData = (querySnapshot) =>
   querySnapshot.docs.reduce((acc, doc) => {
     const { productName, listToken, timeFrame, lastPurchaseDate } = doc.data();

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -36,7 +36,7 @@ export const useProducts = () => {
       // Stop listening to changes from Firebase
       unsubscribe();
     };
-  }, []);
+  }, [storedValue]);
 
   return { products, loading, error };
 };

--- a/src/pages/List/styles.css
+++ b/src/pages/List/styles.css
@@ -1,0 +1,68 @@
+/* Customize the label (the container) */
+.checkbox-label {
+  display: block;
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+  padding-left: 35px;
+  text-align: left;
+}
+
+/* Hide the browser's default checkbox */
+.checkbox-label input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+.checkbox-item {
+  margin-bottom: 10px;
+}
+
+/* Create a custom checkbox */
+.checkmark {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  height: 18px;
+  width: 18px;
+  border: 1px solid black;
+  border-radius: 4px;
+}
+
+/* Create the checkmark/indicator (hidden when not checked) */
+.checkmark:after {
+  content: '';
+  position: absolute;
+  display: none;
+}
+
+/* Show the checkmark when checked */
+.checkbox-label input:checked ~ .checkmark:after {
+  display: block;
+}
+
+/* Style the checkmark/indicator */
+.checkbox-label .checkmark:after {
+  left: 4px;
+  top: 1px;
+  width: 6px;
+  height: 8px;
+  border: solid black;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.checkbox-timeFrame-7 {
+  background-color: #fcb6b6;
+}
+
+.checkbox-timeFrame-14 {
+  background-color: #fff0d4;
+}
+
+.checkbox-timeFrame-30 {
+  background-color: #e5f5e2;
+}

--- a/src/utils/compareDates.js
+++ b/src/utils/compareDates.js
@@ -1,0 +1,10 @@
+/*
+This function receives a Date JS Object and returns 
+true IF it has not passed more than one day, otherwise returns
+false IF it has passed more than 1 day
+*/
+export const compareDates = (date) => {
+  const today = new Date();
+  const diff = (date.getTime() - today.getTime()) / (1000 * 60 * 60);
+  return Math.abs(Math.round(diff)) <= 24 ? true : false;
+};

--- a/src/utils/compareDates.js
+++ b/src/utils/compareDates.js
@@ -5,6 +5,13 @@ false IF it has passed more than 1 day
 */
 export const compareDates = (date) => {
   const today = new Date();
-  const diff = (date.getTime() - today.getTime()) / (1000 * 60 * 60);
-  return Math.abs(Math.round(diff)) <= 24 ? true : false;
+  /*1000 = 1 second
+    60=1min
+    60=1h
+    We're taking the difference betweent two dates in milliseconds
+    given by the getTime() method and transform it to hours.
+  */
+  const millisecondsDifference =
+    (date.getTime() - today.getTime()) / (1000 * 60 * 60);
+  return Math.abs(Math.round(millisecondsDifference)) <= 24 ? true : false;
 };

--- a/src/utils/firebaseUtils.js
+++ b/src/utils/firebaseUtils.js
@@ -1,5 +1,4 @@
 // In this file we add the functions that access Firebase (get, add, update)
-
 import {
   addDoc,
   collection,

--- a/src/utils/firebaseUtils.js
+++ b/src/utils/firebaseUtils.js
@@ -1,5 +1,14 @@
+// In this file we add the functions that access Firebase (get, add, update)
+
+import {
+  addDoc,
+  collection,
+  updateDoc,
+  doc,
+  serverTimestamp,
+  getDocs,
+} from '@firebase/firestore';
 import { db } from '../lib/firebase';
-import { addDoc, collection, getDocs } from '@firebase/firestore';
 
 export const addProduct = ({
   productName,
@@ -11,8 +20,16 @@ export const addProduct = ({
     productName,
     timeFrame,
     lastPurchaseDate,
-    date: Date.now(),
+    createdAt: serverTimestamp(),
   });
+
+export const updatePurchaseDate = (productID, listToken) => {
+  const productRef = doc(db, listToken, productID);
+
+  return updateDoc(productRef, {
+    lastPurchaseDate: serverTimestamp(),
+  });
+};
 
 /** created to validate the token in join-list and display the message
  * when the token does not exist in /welcome */

--- a/src/utils/timeFrames.js
+++ b/src/utils/timeFrames.js
@@ -1,0 +1,5 @@
+export const TimeFrames = {
+  7: 'Soon',
+  14: 'Kind of soon',
+  30: 'Not soon',
+};


### PR DESCRIPTION


## Description

We added in `src/utils`:

- timeFrames: a JS object where we declare how soon the item can be bought again. This means, 7: soon; 14: kind of soon; 30: not soon.
- compareDates: a function that receives a Javascript date object and compares to today's date the difference in hours. It returns true if there hasn't passed more than 24h otherwise returns false.

The user can check the item and it will remain checked for 1 day.

## Related Issue

Closes #8.

## Acceptance Criteria

- El usuario puede tocar un checkbox o un elemento similar de la interfaz de usuario para marcar un artículo de la lista como "comprado".
- El artículo debe aparecer como 'checkeado' durante 24 horas después de la compra (es decir, suponemos que el usuario no necesita comprar el artículo de nuevo durante al menos 1 día)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

![image](https://user-images.githubusercontent.com/37032132/139173425-cf64e252-0841-4df3-bcf5-40270f2777b2.png)


## Testing Steps / QA Criteria

- From your terminal, pull down this branch with `git pull origin il-yu-confirm-product-purchase` and check that branch out with `git checkout il-yu-confirm-product-purchase`
- Insert `isa-collection` token and check on one product. It should remain like that for 1 day. To try this, then go to Firestore and change the date from the product, then it'll be unchecked.

