### PR TITLE
Fix inactive criteria

### DIFF
--- a/src/components/add-form/index.js
+++ b/src/components/add-form/index.js
@@ -67,7 +67,7 @@ const AddForm = ({ formState, handleForm }) => (
           type="radio"
           id="not-soon"
           name="timeFrame"
-          value={TimeFrames.notSoon}
+          value={TimeFrames.notAnySoon}
           onChange={(event) => handleForm(event)}
           checked={formState.timeFrame === TimeFrames.notAnySoon}
         />

--- a/src/components/add-form/index.js
+++ b/src/components/add-form/index.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import './styles.css';
-
-const TimeFrames = {
-  soon: '7',
-  kindOfSoon: '14',
-  notSoon: '30',
-};
+import { TimeFrames } from '../../utils/timeFrames';
 
 const AddForm = ({ formState, handleForm }) => (
   <div className="addform-container">

--- a/src/components/add-form/index.js
+++ b/src/components/add-form/index.js
@@ -69,7 +69,7 @@ const AddForm = ({ formState, handleForm }) => (
           name="timeFrame"
           value={TimeFrames.notSoon}
           onChange={(event) => handleForm(event)}
-          checked={formState.timeFrame === TimeFrames.notSoon}
+          checked={formState.timeFrame === TimeFrames.notAnySoon}
         />
         Not soon
       </label>

--- a/src/helpers/firebaseHelpers.js
+++ b/src/helpers/firebaseHelpers.js
@@ -18,6 +18,7 @@ export const parseData = (querySnapshot) =>
           product.daysUntilNextPurchase,
           product.lastPurchaseDate,
           product.numberOfPurchases,
+          product.timeFrame,
         ),
       },
     ];

--- a/src/utils/getKeyByValue.js
+++ b/src/utils/getKeyByValue.js
@@ -7,7 +7,6 @@ export const getKeyByValue = (object, value) => {
    **/
 
   for (var prop in object) {
-    debugger;
     if (object.hasOwnProperty(prop) && object[prop] === value) {
       return prop;
     }

--- a/src/utils/getKeyByValue.js
+++ b/src/utils/getKeyByValue.js
@@ -1,0 +1,15 @@
+export const getKeyByValue = (object, value) => {
+  /**
+   * Loops trough the object to search for the key that holds a given value
+   * @param {object} object
+   * @param {string} value - Can be any, but in this case is a string
+   * that comes from the timeFrame from Firestore
+   **/
+
+  for (var prop in object) {
+    debugger;
+    if (object.hasOwnProperty(prop) && object[prop] === value) {
+      return prop;
+    }
+  }
+};

--- a/src/utils/nextPurchaseDay.js
+++ b/src/utils/nextPurchaseDay.js
@@ -1,4 +1,6 @@
 import { diffBetweenTodayAndDate } from './diffBetweenTodayAndDate';
+import { TimeFrames } from './timeFrames';
+import { getKeyByValue } from './getKeyByValue';
 /***
  * First we verify by specificity and
  * we return the string that is used for the
@@ -9,6 +11,7 @@ export const nextPurchaseDay = (
   daysUntilNextPurchase,
   lastPurchaseDate,
   numberOfPurchases,
+  timeFrame,
 ) => {
   /**
    * After some checks, we noticed lastPurchasedDate is a Date object
@@ -28,7 +31,11 @@ export const nextPurchaseDay = (
   const nextEstimatedPurchase = 2 * daysUntilNextPurchase;
 
   if (numberOfPurchases === 0) {
-    return 'soon';
+    /*
+    This either returns a string with soon, kindOfSoon or notAnySoon
+    that'll depend on the timeframe that comes from Firestore
+    */
+    return getKeyByValue(TimeFrames, timeFrame);
   }
   if (
     numberOfPurchases === 1 ||

--- a/src/utils/nextPurchaseDay.js
+++ b/src/utils/nextPurchaseDay.js
@@ -27,6 +27,9 @@ export const nextPurchaseDay = (
   const daysSinceLastPurchase = diffBetweenTodayAndDate(lastPurchase);
   const nextEstimatedPurchase = 2 * daysUntilNextPurchase;
 
+  if (numberOfPurchases === 0) {
+    return 'soon';
+  }
   if (
     numberOfPurchases === 1 ||
     daysSinceLastPurchase >= nextEstimatedPurchase

--- a/src/utils/timeFrames.js
+++ b/src/utils/timeFrames.js
@@ -8,3 +8,9 @@ export const TimeFrameLabels = {
   kindOfSoon: 'You are expected to buy this item kind of soon',
   notAnySoon: 'You are not expected to buy this item any time soon',
 };
+
+export const TimeFrames = {
+  soon: '7',
+  kindOfSoon: '14',
+  notAnySoon: '30',
+};


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

Introduces a new function `getKeyByValue` where it receives an object and a value. In this case the object is TimeFrames and the value is the timeFrame from Firestore, then it'll return the key from that value

## Related Issue

Closes #47 

## Acceptance Criteria

Items with zero purchases should use the color that matches their given timeFrame 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    ✓ | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before




### After




## Testing Steps / QA Criteria

- `git fetch`
- `git checkout fix-inactive-criteria`
-  `npm start`
- Create a new item and check it keeps the color associated to the time frame that was choosen

